### PR TITLE
Implement troubleshooting page and toggle.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,16 @@ https://github.com/Tymotex/InkMemories/assets/54927071/7238f156-209b-4a7c-9688-9
 
 ## Usage Notes
 
-Follow the ['Setup Instructions'](#setup-instructions) to begin running Ink Memories.
+Follow the ['Setup Instructions'](#setup-instructions) to set up and begin running Ink Memories on a new Pi zero.
 
+InkMemories will automatically display a new image to the screen every hour.
+
+Using the buttons:
 - Press the top left button (labeled 'A') to force refresh a new image.
-- Press the bottom left button (labeled 'D') to gracefully shut down the system.
+- Press the second button from the top (labeled 'B') to enter debug mode which displays some logs from the main Python script.
+- While in debug mode, press the third button from the top (labeled 'C') to refresh the troubleshooting screen.
+    - Note: The troubleshooting screen does not refresh by itself. Real-time updates are not feasible when the eink display used here takes several seconds to refresh.
+- Press the bottom left button (labeled 'D') to begin gracefully shutting down the system.
   - Unplug after several seconds to disconnect power.
   - The image will persist on the eInk display indefinitely and without power.
   - Upon reconnecting to power, the system will automatically begin refreshing the image periodically again.
@@ -59,6 +65,7 @@ These instructions assume that you have set up Raspbian OS.
         ```sh
         sudo systemctl status ink-memories-image-source.service
         sudo systemctl status ink-memories-displayer.service
+        sudo systemctl status debug-logs-html-snapshotter.service
         ```
 
     - Manage Ink Memories with `systemctl`:
@@ -67,6 +74,7 @@ These instructions assume that you have set up Raspbian OS.
         # Kill the service.
         sudo systemctl stop ink-memories-image-source.service
         sudo systemctl stop ink-memories-displayer.service
+        sudo systemctl stop debug-logs-html-snapshotter.service
         ```
 
     - For reference, in my case I supplied these args to setup.sh when it prompted for them:
@@ -126,6 +134,27 @@ image (e.g. one that includes the apparent subject of the photo or the
 photographee's faces.)
 
 ![center crop demonstration](./assets/crop.png)
+
+### Debug Mode
+
+Pressing 'B' will toggle debug mode, showing a troubleshooting screen. Behind
+the scenes, a log file is transformed into an HTML file, then the Chromium CLI
+is used to take a headless snapshot of that HTML file. Being an HTML file, the
+troubleshooting page can be customised with other content, as well as CSS. Since
+this project doesn't have too many failure modes, a simple dump of the logs is
+all that's displayed here.
+
+The InkyImpressions does not provide native support for displaying HTML files,
+so this project introduces a daemon, `debug-logs-html-snapshotter`, that
+polls the log file and formats the most recent logs into an HTML file, and takes
+a screenshot of it, bounded to the dimensions of the eInk display. (An
+improvement to this implementation is to use a file watcher on the log file to
+trigger the transformation to HTML instead of polling the log file every few
+seconds.)
+
+From the `ScreenManager`'s perspective, the debug screen is created and managed
+externally - it simply just depends on it being there and displays whatever is
+there.
 
 ## Potential Features & Improvements
 This was a rushed project. Here are some ideas for how to improve upon the MVP:

--- a/displayer_service/.gitignore
+++ b/displayer_service/.gitignore
@@ -3,3 +3,5 @@ __pycache__/
 current_image.png
 .ink-memories-log
 venv/
+debug-screen.png
+debug-screen.html

--- a/displayer_service/common/display_config.py
+++ b/displayer_service/common/display_config.py
@@ -10,9 +10,6 @@ DEFAULT_DISPLAY_CONFIG = {
         # TODO: Required fields like this should be validated to be set to an existent directory on program startup and log on failure.
         "image_source_dir": "~/Pictures"
     },
-    "logging": {
-        "log_file_path": ".ink-memories-log"
-    }
 }
 
 

--- a/displayer_service/display_config.json
+++ b/displayer_service/display_config.json
@@ -4,7 +4,4 @@
         "allowed_image_extensions": [".jpg", ".jpeg", ".png", ".heic"],
         "image_source_dir": "/home/pi/Pictures/InkMemories"
     },
-    "logging": {
-        "log_file_path": ".ink-memories-log"
-    }
 }

--- a/displayer_service/tests/test_display_config.json
+++ b/displayer_service/tests/test_display_config.json
@@ -4,7 +4,4 @@
         "allowed_image_extensions": [".jpg", ".jpeg", ".png"],
         "image_source_dir": "./test-images"
     },
-    "logging": {
-        "log_file_path": ".ink-memories-log"
-    }
 }

--- a/scripts/debug-logs-html-snapshot.sh
+++ b/scripts/debug-logs-html-snapshot.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+if [ "$#" -ne 1 ]; then
+    echo "Usage: $0 <logs_file_path>"
+    exit 1
+fi
+
+debug_logs_file_path=$1
+
+# Check if the argument is a file.
+if [ ! -f "$debug_logs_file_path" ]; then
+    echo "Error: '$debug_logs_file_path' is not a valid file."
+    exit 1
+fi
+
+# Create an empty log file if it does not exist.
+if [ ! -e "$debug_logs_file_path" ]; then
+    touch "$debug_logs_file_path"
+fi
+
+output_dir=$(dirname "$debug_logs_file_path")
+output_debug_screen_html_file_path="${output_dir}/debug-screen.html"
+output_debug_screen_image_name="debug-screen.png"
+
+while true; do
+    # Capture the most recent several lines and format it into an HTML file.
+    # Note: The HTML file is very barebones currently but can be customised with
+    #       better styling and formatting with CSS.
+    echo "Grabbing recent logs and creating an HTML file."
+    logs=$(tail -50 "$debug_logs_file_path" | tac)
+
+    # Reset the HTML file's contents and write formatted HTML logs to it.
+    echo "" > "$output_debug_screen_html_file_path"
+    echo "$logs" | while IFS= read -r line; do
+        # Wrap each line in <p>...</p> and dump to HTML file.
+        echo "<p>${line}</p>" >> "$output_debug_screen_html_file_path"
+    done
+
+    # Take a screenshot of the HTML file to produce an image file.
+    # Note: What if the HTML file contains too many lines - wouldn't that not
+    #       fit into the output image? Yup - it gets truncated. This is
+    #       acceptable because we usually only care about the most recent logs.
+    output_screenshot_path="${output_dir}/${output_debug_screen_image_name}"
+    echo "Taking screenshot at path: $output_screenshot_path"
+    chromium \
+        --headless \
+        --screenshot="$output_screenshot_path" \
+        --window-size=600,448 \
+        "$output_debug_screen_html_file_path"
+    sleep 5s
+done

--- a/service_files/debug-logs-html-snapshotter.service
+++ b/service_files/debug-logs-html-snapshotter.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Ink Memories Error Log HTML Snapshotter
+
+[Service]
+WorkingDirectory={{INK_MEMORIES_ROOT}}/scripts/debug-logs-html-snapshot.sh
+ExecStart=
+
+[Install]
+WantedBy=multi-user.target

--- a/setup.sh
+++ b/setup.sh
@@ -28,6 +28,9 @@ pre-commit install
 # Installing this fixes it.
 sudo apt-get install libopenblas-dev 
 
+# Chromium is necessary to take headless screenshots of an HTML file.
+sudo apt-get install chromium
+
 #===========================================================================
 #                  Configuring Ink Memories to run as a daemon
 #===========================================================================
@@ -41,7 +44,7 @@ read -p "Enter the name of the shared Google Photos album: " shared_album_name
 
 mkdir -p "${image_src_dir}" 2>&1
 
-for service_file_basename in ink-memories-image-source.service ink-memories-displayer.service; do
+for service_file_basename in ink-memories-image-source.service ink-memories-displayer.service debug-logs-html-snapshotter.service; do
     echo "Making service file, $service_file_basename"
     sed -e "s|{{IMAGE_SRC_DIR}}|${image_src_dir}|g" \
         -e "s|{{INK_MEMORIES_ROOT}}|${ink_memories_root}|g" \


### PR DESCRIPTION
This PR includes two main changes:
- Toggling the debug mode to show the troubleshooting screen.
- A new daemon that regularly refreshes the troubleshooting screen image by polling the log file, and transforming it into an HTML file, then screenshotting it headlessly with the Chromium CLI.

Note: Still untested!