### PR TITLE
Add debugging state and handle some exceptions 

### DIFF
--- a/displayer_service/common/image_retriever.py
+++ b/displayer_service/common/image_retriever.py
@@ -60,7 +60,8 @@ class ImageRetriever:
     def get_random_image(self) -> ImageType:
         """Retrieves one random image from the image source."""
         all_images = self.get_path_of_all_images()
-        # TODO(image retrieval error): throw(there are no images)
+        if not all_images: 
+            raise Exception("No images were found in fetch, in an attempt to get a random image.")
 
         # Randomly pick an image from all the images.
         chosen_image_file_path = random.choice(all_images)
@@ -73,7 +74,9 @@ class ImageRetriever:
     def get_random_images(self, num_images) -> List[ImageType]:
         """Retrieves `num_images` number of random images from the image source."""
         all_images = self.get_path_of_all_images()
-        # TODO(image retrieval error): throw(there are no images)
+        if not all_images: 
+            raise Exception(f"No images were found in fetch, in an attempt to get {num_images} random images. ")
+
 
         num_images = min(num_images, len(all_images))
         # Randomly pick an image from all the images.

--- a/displayer_service/common/screen_manager.py
+++ b/displayer_service/common/screen_manager.py
@@ -174,20 +174,22 @@ class ScreenManager:
         self.logger.info(
             [img.filename for img in list(self.image_queue.queue)])
 
+        try:
+            next_image = self.image_queue.get()
+        except queue.Empty:
+            # TODO: handle case where this this is requested multiple times. 
+            self.logger.error("Tried to set the next image, but queue was empty.")
+
+            self.logger.info("Repopulating the image buffer.")
+            # TODO: consider consolidating this logic with the initial image population.
+            chosen_images = self.image_retriever.get_random_images(
+                    INITIAL_QUEUE_SIZE)
+            for img in chosen_images:
+                self.image_queue.put(img)
+
+            next_image = self.image_queue.get()
+
         with self.screen_lock:
-            try:
-                next_image = self.image_queue.get()
-            except queue.Empty:
-                self.logger.error("Tried to set the next image, but queue was empty.")
-
-                self.logger.info("Repopulating the image buffer.")
-                chosen_images = self.image_retriever.get_random_images(
-                        INITIAL_QUEUE_SIZE)
-                for img in chosen_images:
-                    self.image_queue.put(img)
-
-                next_image = self.image_queue.get()
-
             self.set_image(next_image)
         self.image_retriever.clean_up_image(next_image)
 

--- a/displayer_service/common/screen_manager.py
+++ b/displayer_service/common/screen_manager.py
@@ -46,6 +46,11 @@ class ScreenManager:
     # Utility for retrieving images from the image source.
     image_retriever: ImageRetriever
 
+    # Whether the user is currently in debugging mode. 
+    # The user can enter debugging mode by pressing the 'B' button. 
+    # Debugging mode can be exited via a force image refresh ('A' button).
+    is_debugging = False
+
     def __init__(self):
         with self.screen_lock:
             self.logger = logging.getLogger(__name__)
@@ -132,8 +137,14 @@ class ScreenManager:
         """Periodically displays a new image."""
         image_refresh_period_secs = self.display_config.config['display']['refresh_period_secs']
         while True:
-            self.logger.info("Attempting to set a new random image.")
+            self.logger.info("Automatic image refresh requested.")
 
+            if self.is_debugging: 
+                self.logger.info(
+                    "Debugging mode is ON. Skipping image refresh."
+                )
+                continue
+            
             self.output_and_queue_image()
 
             self.logger.info("Waiting for %s seconds.",
@@ -177,6 +188,11 @@ class ScreenManager:
 
         self.logger.info("Done writing image.")
 
+    def push_debugger_update(self):
+        self.logger.info("Fetching the latest debugging information.")
+
+        # TODO: Fetch and update the display with the latest debugging information
+
     def handle_button_press(self, pressed_pin):
         """Executes specific actions on button presses.
 
@@ -193,10 +209,13 @@ class ScreenManager:
                 self.logger.info(
                     "Skipping image refresh because refresh is already underway.")
                 return
+            self.is_debugging = False
             self.output_and_queue_image()
         elif label == 'B':
             self.logger.info(
-                "User pressed B. Nothing is implemented for this button.")
+                "User pressed B." + "Entering debugging mode." if self.is_debugging else "Refreshing debugger.")
+            self.is_debugging = True
+            self.push_debugger_update()
         elif label == 'C':
             self.logger.info(
                 "User pressed C. Nothing is implemented for this button.")

--- a/displayer_service/common/screen_manager.py
+++ b/displayer_service/common/screen_manager.py
@@ -175,7 +175,19 @@ class ScreenManager:
             [img.filename for img in list(self.image_queue.queue)])
 
         with self.screen_lock:
-            next_image = self.image_queue.get()
+            try:
+                next_image = self.image_queue.get()
+            except queue.Empty:
+                self.logger.error("Tried to set the next image, but queue was empty.")
+
+                self.logger.info("Repopulating the image buffer.")
+                chosen_images = self.image_retriever.get_random_images(
+                        INITIAL_QUEUE_SIZE)
+                for img in chosen_images:
+                    self.image_queue.put(img)
+
+                next_image = self.image_queue.get()
+
             self.set_image(next_image)
         self.image_retriever.clean_up_image(next_image)
 

--- a/displayer_service/common/screen_manager.py
+++ b/displayer_service/common/screen_manager.py
@@ -143,13 +143,11 @@ class ScreenManager:
                 self.logger.info(
                     "Debugging mode is ON. Skipping image refresh."
                 )
-                continue
-            
-            self.output_and_queue_image()
+            else:
+                self.output_and_queue_image()
 
             self.logger.info("Waiting for %s seconds.",
                              image_refresh_period_secs)
-
             time.sleep(image_refresh_period_secs)
 
     def queue_image(self):

--- a/displayer_service/common/screen_manager.py
+++ b/displayer_service/common/screen_manager.py
@@ -64,16 +64,20 @@ class ScreenManager:
             self.image_retriever = ImageRetriever(
                 self.logger, self.display_config)
 
-            # Populate image buffer
-            try:
-                chosen_images = self.image_retriever.get_random_images(
-                    INITIAL_QUEUE_SIZE)
-                for img in chosen_images:
-                    self.image_queue.put(img)
-            except Exception as e: 
-                self.logger.error(e)
-                # TODO: Initial fetch has failed... Maybe ask the user to restart. 
-                
+            # Populate the image buffer with some intiial images. 
+            # Keep trying until it is populated. 
+            chosen_images = None
+            while chosen_images is None:
+                try:
+                    chosen_images = self.image_retriever.get_random_images(
+                        INITIAL_QUEUE_SIZE)
+                except Exception as e: 
+                    self.logger.error(e)
+                    self.logger.info("Initial population of images has failed. Trying again in 300 seconds.")
+                    time.sleep(300)
+
+            for img in chosen_images:
+                self.image_queue.put(img)
 
     def initialise_eink_display(self) -> None:
         """Initialises the e-ink display for usage."""

--- a/displayer_service/common/screen_manager.py
+++ b/displayer_service/common/screen_manager.py
@@ -65,10 +65,15 @@ class ScreenManager:
                 self.logger, self.display_config)
 
             # Populate image buffer
-            chosen_images = self.image_retriever.get_random_images(
-                INITIAL_QUEUE_SIZE)
-            for img in chosen_images:
-                self.image_queue.put(img)
+            try:
+                chosen_images = self.image_retriever.get_random_images(
+                    INITIAL_QUEUE_SIZE)
+                for img in chosen_images:
+                    self.image_queue.put(img)
+            except Exception as e: 
+                self.logger.error(e)
+                # TODO: Initial fetch has failed... Maybe ask the user to restart. 
+                
 
     def initialise_eink_display(self) -> None:
         """Initialises the e-ink display for usage."""
@@ -152,7 +157,11 @@ class ScreenManager:
 
     def queue_image(self):
         """Adds a random image to image buffer"""
-        self.image_queue.put(self.image_retriever.get_random_image())
+        try:
+            self.image_queue.put(self.image_retriever.get_random_image())
+        except Exception as e:
+            self.logger.error(e)
+            self.logger.info("Failed to queue image. Size of queue: %s", self.image_queue.qsize())
 
     def output_and_queue_image(self):
         """Displays the next image in the image queue, and adds a new image to the queue."""
@@ -173,8 +182,6 @@ class ScreenManager:
     def set_image(self, img):
         """Sets a new random image chosen from the images source.
         """
-        # TODO: Catch and handle image fetch failure (probably due to network failure, invalid API credentials).
-
         # Pre-process the image.
         width, height = self.eink_display.resolution
         img = image_processor.central_crop(img,  width / height)


### PR DESCRIPTION
- added debugging state.
    - Note: There is no “toggle” of the debugging state.
        - [Option 1, chosen] Pressing “B” will refresh and display the debugging screen. Pressing “B” simply displays the latest debugging info regardless of current state. Pressing “A” will force refresh the image, and exit debugging state. There is still a `is_debugging` bool, which disables hourly auto refresh.
            - PRO: Only requires 1 button for debugger functionality
            - PRO: Simpler, does not require loading previous current image
            - CON: Cannot return to the previously displayed current image
                - This is quite trivial on a system where the user can only see random images without any control anyway.
        - [Option 2, alternative] Pressing “B” will toggle ON debugger mode if it’s off, and enter the debugging screen. Pressing “B” will toggle OFF debugger mode if it’s on and return to the previously displayed image. Pressing “C” will refresh the debugging screen if we’re in debugging mode, or do nothing if we’re not in debugging mode.
            - PRO: Allows us to return to the previously displayed current image
            - CON: Requires 2 button to be taken for debugger functionality
            - CON: More complicated, requires logic for C button behaviour and for returning to previous current image.
    - `push_debugger_update` needs to be populated with logic for fetching the latest debugging information and updating the display with it.  @Tymotex 
- cleaned up some exception handling TODOs
- added logic for raising exceptions when we try to fetch a new image (or images), but no images are found in the image source.
    - this gets raised in image_retriever on `get_random_image` and `get_random_images`
- handle exceptions in screen_manager
    - in the initial population of images in `init`
        - Previously we try (once) to populate the image buffer, and if we fail, we fail, and the user has to restart.
        - Updated this to block and continue trying (every 5 minutes) until we are able to populate the image buffer. This provides a non-intrusive way to let the app silently keep trying in the background without the user having to restart.
            - Considerations: Do we want this? and how does this interfere with the user wanting to enter debugging mode?
    - in `queue_image`, catch the no images found exception and log it appropriately.
        - Considerations: anything else we want to do? retry mechanism? 
    - in `output_and_queue_image`,  update this to repopulate the entire queue if it is empty if we try to get from the queue but it’s empty.
        - Previously, if the image_queue somehow becomes empty, and we perform get() on it, a Queue.Empty exception is raise, but not caught, leading the program to error out.
        - Updated this to catch the Queue.Empty exception and try to repopulate the whole queue with INITIAL_QUEUE_SIZE number of images, and then display an image once it’s available.
            - Consideration: what if the repopulation fails? there is no retry mechanism at the moment. but at least the user is no worse-off than before.
            - Consideration: what if the user presses “A” multiple times while the queue is empty - would we end up queueing N * INITIAL_QUEUE_SIZE number of images, where N is the number of times the user pressed the button?
